### PR TITLE
Added the ability to supply a queryset to the interrogator from the original app.

### DIFF
--- a/data_interrogator/admin/views.py
+++ b/data_interrogator/admin/views.py
@@ -14,6 +14,7 @@ class AdminInterrogationRoom(InterrogationView):
     report_models = Allowable.ALL_MODELS
     allowed = Allowable.ALL_APPS
     excluded = []
+    # model_queryset = None
 
     @method_decorator(user_passes_test(lambda u: u.is_superuser))
     def get(self, request):

--- a/data_interrogator/interrogators.py
+++ b/data_interrogator/interrogators.py
@@ -156,12 +156,13 @@ class Interrogator:
         return field.name.startswith('_')
 
     def get_model_queryset(self, qs_restriction_function=None):
-        qs = self.base_model.objects.all()
+        return self.base_model.objects.all()
+        # qs = self.base_model.objects.all()
+
+        # if qs_restriction_function is None:
+        #     return qs
         
-        if qs_restriction_function is None:
-            return qs
-        
-        return qs_restriction_function(qs)
+        # return qs_restriction_function(qs)
 
     def process_annotation_concat(self, column):
         pass
@@ -369,7 +370,7 @@ class Interrogator:
 
         return filters_all, _filters,  annotations, expression_columns, excludes
 
-    def generate_queryset(self, base_model, columns=None, filters=None, order_by=None, limit=None, offset=0,**kwargs):
+    def generate_queryset(self, base_model, columns=None, filters=None, order_by=None, limit=None, offset=0, **kwargs):
         errors = []
         annotation_filters = {}
 

--- a/data_interrogator/interrogators.py
+++ b/data_interrogator/interrogators.py
@@ -474,15 +474,18 @@ class Interrogator:
         if columns is None: columns = []
 
         errors = []
-        base_model_data = {}
+        
         output_columns = []
         count = 0
         rows = []
+        
+        self.base_model, base_model_data = self.validate_report_model(base_model)
+        base_model_data = {}
 
         # gets model supplied - if not supplied, gets model the original way
         if not model_queryset:
-            # model_queryset = self.get_model_queryset()
-            model_queryset  = base_model.objects.all()
+            model_queryset = self.get_model_queryset()
+            # model_queryset  = base_model.objects.all() - didnt work
 
         try:
             rows, errors, output_columns, base_model_data = self.generate_queryset(

--- a/data_interrogator/interrogators.py
+++ b/data_interrogator/interrogators.py
@@ -114,6 +114,7 @@ class Interrogator:
     #   Not this yet: ('app_label', 'model_name', ['list of field names'])
     allowed = Allowable.ALL_MODELS
     excluded = []
+    # model_queryset = None
 
 
     def __init__(self, report_models=None, allowed=None, excluded=None):
@@ -123,6 +124,8 @@ class Interrogator:
             self.allowed = allowed
         if excluded is not None:
             self.excluded = excluded
+        
+        # this could be a good place to add the qs
 
         # Clean up rules if they aren't lower cased.
         fixed_excluded = []
@@ -465,7 +468,7 @@ class Interrogator:
 
         return rows, errors, output_columns, base_model_data
 
-    def interrogate(self, base_model, columns=None, filters=None, order_by=None, limit=None, offset=0, **kwargs):
+    def interrogate(self, base_model, columns=None, filters=None, order_by=None, limit=None, offset=0, model_queryset=None):
         if order_by is None: order_by = []
         if filters is None: filters = []
         if columns is None: columns = []
@@ -477,7 +480,6 @@ class Interrogator:
         rows = []
 
         # gets model from kwargs - if not supplied, gets model the original way
-        model_queryset = kwargs.get("model_queryset")
         if not model_queryset:
             model_queryset = self.base_model.objects.all()
 

--- a/data_interrogator/interrogators.py
+++ b/data_interrogator/interrogators.py
@@ -479,9 +479,9 @@ class Interrogator:
         count = 0
         rows = []
 
-        # gets model from kwargs - if not supplied, gets model the original way
+        # gets model supplied - if not supplied, gets model the original way
         if not model_queryset:
-            model_queryset = self.base_model.objects.all()
+            model_queryset = self.get_model_queryset()
 
         try:
             rows, errors, output_columns, base_model_data = self.generate_queryset(

--- a/data_interrogator/interrogators.py
+++ b/data_interrogator/interrogators.py
@@ -481,7 +481,8 @@ class Interrogator:
 
         # gets model supplied - if not supplied, gets model the original way
         if not model_queryset:
-            model_queryset = self.get_model_queryset()
+            # model_queryset = self.get_model_queryset()
+            model_queryset  = base_model.objects.all()
 
         try:
             rows, errors, output_columns, base_model_data = self.generate_queryset(

--- a/data_interrogator/interrogators.py
+++ b/data_interrogator/interrogators.py
@@ -483,8 +483,9 @@ class Interrogator:
         base_model_data = {}
 
         # gets model supplied - if not supplied, gets model the original way
-        if not model_queryset:
-            model_queryset = self.get_model_queryset()
+        if model_queryset is None:
+            # model_queryset = self.get_model_queryset()
+            model_queryset = self.base_model.objects.all()
             # model_queryset  = base_model.objects.all() - didnt work
 
         try:

--- a/data_interrogator/views/views.py
+++ b/data_interrogator/views/views.py
@@ -28,6 +28,7 @@ class InterrogationMixin:
     allowed = Allowable.ALL_APPS
     excluded = []
     # might need to remove this here
+    model_queryset = None
 
     def get_interrogator(self):
         return self.interrogator_class(self.report_models, self.allowed, self.excluded)

--- a/data_interrogator/views/views.py
+++ b/data_interrogator/views/views.py
@@ -75,6 +75,8 @@ class InterrogationView(UserHasPermissionMixin, View, InterrogationMixin):
             form_data['order_by'] = form.cleaned_data.get('sort_by', [])
             form_data['columns'] = form.cleaned_data.get('columns', [])
             form_data['base_model'] = form.cleaned_data['lead_base_model']
+            # added this field
+            form_data['model_queryset'] = form.cleaned_data.get('model_queryset',[])
 
             # Add bound form to data
             form_data['form'] = form
@@ -98,7 +100,10 @@ class InterrogationView(UserHasPermissionMixin, View, InterrogationMixin):
                 data = self.interrogate(request_params['base_model'],
                                         columns=request_params['columns'],
                                         filters=request_params['filters'],
-                                        order_by=request_params['order_by'])
+                                        order_by=request_params['order_by'],
+                                        # added
+                                        model_queryset=request_params['model_queryset']
+                                        )
                 if form:
                     # Update form to use the bound form
                     form = request_params['form']
@@ -106,6 +111,9 @@ class InterrogationView(UserHasPermissionMixin, View, InterrogationMixin):
         if form:
             data['form'] = form
         return self.render_to_response(data)
+    
+    # get_queryset(self):
+
 
 
 class BaseModelOptionsApi(UserHasPermissionMixin, InterrogationMixin, View):
@@ -127,7 +135,10 @@ class ApiInterrogationView(InterrogationView):
         request_data = {'filters': self.request.GET.getlist('filter_by', []),
                         'order_by': self.request.GET.getlist('sort_by', []),
                         'columns': self.request.GET.getlist('columns', []),
-                        'base_model': self.request.GET.get('lead_base_model')}
+                        'base_model': self.request.GET.get('lead_base_model'),
+                        # added
+                        'model_queryset': self.request.GET.get('model_queryset')
+                        }
 
         transformed_request = {}
 


### PR DESCRIPTION
This pr adds the ability to supply a queryset from the original app. This means a queryset can be restricted with regard to the permissions, model and user restrictions of the app using the interrogator. 

The passing of a queryset occurs in the same way the report models, allowed and excluded models are passed to the app.

